### PR TITLE
BDC-14 Build Image Update

### DIFF
--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -50,7 +50,7 @@ Resources:
       EncryptionKey: !ImportValue cfn-utilities:ArtifactKeyArn
       Environment:
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         ComputeType: BUILD_GENERAL1_SMALL
         EnvironmentVariables:
           - Name: ARTIFACT_STORE


### PR DESCRIPTION
This updates the build image used for this repository to Amazon Linux 2 Standard 3 for continued support